### PR TITLE
change asserts to true summ of Primes

### DIFF
--- a/issues/sum_primes.yml
+++ b/issues/sum_primes.yml
@@ -6,10 +6,10 @@ description: "Write some code to sum the first 1000 primes without using Ruby's 
 checks:
   ruby:
     asserts:
-      - assert_equal 3682913, sum_primes(1000)
-      - assert_equal 111587, sum_primes(200)
+      - assert_equal 76127, sum_primes(1000)
+      - assert_equal 4227, sum_primes(200)
 
   javascript:
     asserts:
-      - assertEqual(3682913, sumPrimes(1000))
-      - assertEqual(111587, sumPrimes(200))
+      - assertEqual(76127, sumPrimes(1000))
+      - assertEqual(4227, sumPrimes(200))


### PR DESCRIPTION
Изменил суммы в ассертах для 1000 и 200 элементов, так как предыдущие были не верны. Результаты проверены на языке Ruby с библиотекой Prime.
