### PR TITLE
Fix assert 5 in mash and workaround in array_fetch

### DIFF
--- a/issues/array_fetch.yml
+++ b/issues/array_fetch.yml
@@ -10,7 +10,7 @@ checks:
     asserts:
       - assert_equal 'b', fetch(list, 1, 'd')
       - assert_equal 'd', fetch(list, 5, 'd')
-      - assert_equal 'c', fetch(list, -1, 'a')
+      - assert_equal 'c', fetch(list, -1, 'd')
       - assert_equal 'd', fetch(list, -5, 'd')
   javascript:
     setup: |
@@ -19,5 +19,5 @@ checks:
     asserts:
       - assertEqual('b', fetch(list, 1, 'd'))
       - assertEqual('d', fetch(list, 5, 'd'))
-      - assertEqual('c', fetch(list, -1, 'a'))
+      - assertEqual('c', fetch(list, -1, 'd'))
       - assertEqual('d', fetch(list, -5, 'd'))


### PR DESCRIPTION
Assert 6 says Mash.author should be Mash object. Then assert 5 should get Mash.author.name instead of Mash object Mash.author 
