### PR TITLE
Disabled tasks

### DIFF
--- a/src/battle_asserts/issues/flatten.clj
+++ b/src/battle_asserts/issues/flatten.clj
@@ -6,6 +6,8 @@
 (def description "Given an array, possibly with more arrays inside, return a 1-dimensional
                   flat array with all the values in the initial order.")
 
+(defn disabled [] true)
+
 (defn arguments-generator
   []
   (let [nested (gen/list (gen/one-of [gen/int (gen/list gen/int)]))]

--- a/src/battle_asserts/issues/parse_post_form_params.clj
+++ b/src/battle_asserts/issues/parse_post_form_params.clj
@@ -7,6 +7,8 @@
 
 (def description "Parse a given request string.")
 
+(defn disabled [] true)
+
 (defn to-query [value]
   (letfn [(to-string [name value]
             (cond

--- a/src/battle_asserts/issues/remove_duplicates.clj
+++ b/src/battle_asserts/issues/remove_duplicates.clj
@@ -7,6 +7,8 @@
                   Repeated elements should be replaced with a single element.
                   The order of the elements should not be changed.")
 
+(defn disabled [] true)
+
 (defn arguments-generator []
   (letfn [(add-duplicates [coll]
             (concat coll (repeatedly (inc (rand-int 5))

--- a/src/battle_asserts/issues/rotate_sequence.clj
+++ b/src/battle_asserts/issues/rotate_sequence.clj
@@ -6,6 +6,8 @@
 (def description "Given an array and a number, generate an array with values shifted left or right by a given number. 
                   The number could be positive or negative; positive number shifts the array forward, negative shifts it backwards.")
 
+(defn disabled [] true)
+
 (defn arguments-generator []
   (gen/tuple gen/int (gen/not-empty (gen/vector gen/int))))
 


### PR DESCRIPTION
Чтобы спокойно ввести сигнатуры в обновленный процесс проверки решений игроков, нужно убрать задачи, которые нельзя внедрить.