### PR TITLE
Fix arguments dash

### DIFF
--- a/src/battle_asserts/issues/missing_third_angle.clj
+++ b/src/battle_asserts/issues/missing_third_angle.clj
@@ -11,8 +11,8 @@
                   The sum of angles of any triangle is always 180 degrees.")
 
 (def signature
-  {:input [{:argument-name "first-angle" :type {:name "integer"}}
-           {:argument-name "second-angle" :type {:name "integer"}}]
+  {:input [{:argument-name "first" :type {:name "integer"}}
+           {:argument-name "second" :type {:name "integer"}}]
    :output {:type {:name "string"}}})
 
 (defn arguments-generator
@@ -24,9 +24,9 @@
    {:expected "acute" :arguments [135 11]}
    {:expected "right" :arguments [45 45]}])
 
-(defn solution [first-angle second-angle]
-  (let [third-angle (- 180 first-angle second-angle)]
+(defn solution [first second]
+  (let [third (- 180 first second)]
     (cond
-      (> third-angle 90) "obtuse"
-      (< third-angle 90) "acute"
+      (> third 90) "obtuse"
+      (< third 90) "acute"
       :else "right")))


### PR DESCRIPTION
Фикс тире в аргументах, тк в некоторых языках воспринимается как часть кода. Т.е. код невалиден сразу после старта (надо удалять тире/править аргументы в функции)