### PR TITLE
Update deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,15 +5,15 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.5.1"
   :plugins [[lein-kibit "0.1.8"]
-            [lein-cljfmt "0.7.0"]
+            [lein-cljfmt "0.8.0"]
             [jonase/eastwood "0.4.0"]]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [jonase/eastwood "0.4.0" :exclusions  [org.clojure/clojure]]
                  [org.clojure/tools.namespace "1.1.0"]
-                 [org.clojure/data.json "2.2.1"]
+                 [org.clojure/data.json "2.4.0"]
                  [org.clojure/test.check "1.1.0"]
                  [helpshift/faker "0.2.0"]
-                 [clj-commons/clj-yaml "0.7.0"]
+                 [clj-commons/clj-yaml "0.7.107"]
                  [com.velisco/strgen "0.1.8"]
                  [faker "0.2.2"]
                  [kovacnica/clojure.network.ip "0.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.5.1"
   :plugins [[lein-kibit "0.1.8"]
-            [lein-cljfmt "0.8.0"]
+            [lein-cljfmt "0.7.0"]
             [jonase/eastwood "0.4.0"]]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [jonase/eastwood "0.4.0" :exclusions  [org.clojure/clojure]]

--- a/src/battle_asserts/issues/capitalized_words_number.clj
+++ b/src/battle_asserts/issues/capitalized_words_number.clj
@@ -1,7 +1,7 @@
 (ns battle-asserts.issues.capitalized-words-number
   (:require [clojure.test.check.generators :as gen]
-            [miner.strgen :as sg]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [faker.generate :as f]))
 
 (def level :easy)
 
@@ -17,7 +17,7 @@
 
 (defn arguments-generator []
   (gen/tuple
-   (gen/let [words (gen/vector (sg/string-generator #"[A-Za-z]{1,8}") 0 9)]
+   (gen/let [words (gen/vector (gen/elements (f/sentences {:n 2})) 1 9)]
      (gen/return (str/join " " words)))))
 
 (def test-data

--- a/src/battle_asserts/issues/capitalized_words_number.clj
+++ b/src/battle_asserts/issues/capitalized_words_number.clj
@@ -1,6 +1,6 @@
 (ns battle-asserts.issues.capitalized-words-number
   (:require [clojure.test.check.generators :as gen]
-            [clojure.string :as str]
+            [clojure.string :as s]
             [faker.generate :as f]))
 
 (def level :easy)
@@ -18,7 +18,7 @@
 (defn arguments-generator []
   (gen/tuple
    (gen/let [words (gen/vector (gen/elements (f/sentences {:n 2})) 1 9)]
-     (gen/return (str/join " " words)))))
+     (gen/return (s/join " " words)))))
 
 (def test-data
   [{:expected 0
@@ -34,6 +34,6 @@
 
 (defn solution [s]
   (->>
-   (str/split s #" ")
+   (s/split s #" ")
    (filter #(when-let [letter (get % 0)] (Character/isUpperCase letter)))
    (count)))


### PR DESCRIPTION
Remove [this lib](https://github.com/miner/strgen) because after bump it brokes project. Moreover, this lib used only one time.﻿
After bump to 0.8.0 cljfmt, linting messed up.
Eastwood will be bumped in other PR, because after bump he generates many warnings.