### PR TITLE
expected 7 change to 8

### DIFF
--- a/src/battle_asserts/issues/sea_battle.clj
+++ b/src/battle_asserts/issues/sea_battle.clj
@@ -15,7 +15,7 @@
    :output {:type {:name "integer"}}})
 
 (def test-data
-  [{:expected 7
+  [{:expected 8
     :arguments [[[1 0 1 0 0 0]
                  [1 0 0 0 1 1]
                  [0 0 0 0 0 0]


### PR DESCRIPTION
`[1 0 1 0 0 0]` -> +2 = **2** # 1 and 1
`[1 0 0 0 1 1]` ->  +2 = **4** # 1 and 11
`[0 0 0 0 0 0]` -> +0 = **4** # nothing
`[0 1 1 1 0 1]` -> +2 = **6** # 111 and 1
`[0 0 0 0 0 1]` ->  +0 = **6** # zero because this "1" part of the next ship
`[1 1 0 1 0 0]` -> +2 = **8** # 1+11 and 1