### PR TITLE
Fix typo in baudot_code.clj

### DIFF
--- a/src/battle_asserts/issues/baudot_code.clj
+++ b/src/battle_asserts/issues/baudot_code.clj
@@ -78,7 +78,7 @@
    :output {:type {:name "string"}}})
 
 (defn- encrypt [word]
-  (let [dict {"R" " .o.o."
+  (let [dict {"R" ".o.o."
               "J" ".o.oo"
               "C" ".ooo."
               "G" "oo.o."


### PR DESCRIPTION
Исправляет опечатку, из-за которой генерировались неверные тесты для проверки решений
![изображение](https://github.com/hexlet-codebattle/battle_asserts/assets/8749115/a540cef7-4ad3-4657-aaca-d6d4840a87b1)
